### PR TITLE
Documented changing display name of group

### DIFF
--- a/admin_manual/configuration_user/instruction_set_for_groups.rst
+++ b/admin_manual/configuration_user/instruction_set_for_groups.rst
@@ -166,6 +166,49 @@ XML output
     </data>
   </ocs>  
 
+Edit data of a single group
+--------------------------
+
+Edits attributes related to a group. Authentication
+is done by sending a Basic HTTP Authorization header.
+
+**Syntax: ocs/v1.php/cloud/groups/{groupid}**
+
+* HTTP method: PUT
+* PUT argument: key, the field to edit:
+
+  + displayname
+
+* PUT argument: value, the new value for the field
+
+Status codes:
+
+* 100 - successful
+* 101 - not supported by backend
+
+Examples
+^^^^^^^^
+
+::
+
+  $ curl -X PUT http://admin:secret@example.com/ocs/v1.php/cloud/groups/mygroup -d key="displayname" -d value="My Group Name"
+
+* Updates the display name for the group ``mygroup``
+
+XML output
+^^^^^^^^^^
+
+.. code-block:: xml
+
+  <?xml version="1.0"?>
+  <ocs>
+    <meta>
+      <statuscode>100</statuscode>
+      <status>ok</status>
+    </meta>
+    <data/>
+  </ocs>
+
 Delete a group
 --------------
 


### PR DESCRIPTION
This instruction was already added to nextcloud in 2019, see commit https://github.com/nextcloud/server/commit/653628c8fb69dc3f9d26751520f91e43a18f17ae